### PR TITLE
add instructions for added security via basicauth

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,10 +1,19 @@
 localhost {
-	reverse_proxy website:8080
 
-	@rendezvous {
-		header Connection *Upgrade*
-		header Upgrade websocket
-	}
+  # @needauth {
+  #   not remote_ip 11.11.11.11/11 11.111.111.111/11 # Replace with your IP's
+  # }
 
-	reverse_proxy @rendezvous rendezvous:4000
+  # basicauth @needauth {
+  #   username <result of `caddy hash-password` (prompts for password)>
+  # }
+
+  reverse_proxy website:8080
+
+  @rendezvous {
+    header Connection *Upgrade*
+    header Upgrade websocket
+  }
+
+  reverse_proxy @rendezvous rendezvous:4000
 }

--- a/README
+++ b/README
@@ -48,6 +48,10 @@ SERVER SETUP (WITH DOCKER)
     	reverse_proxy @rendezvous rendezvous:4000
     }
 
+    Note there are also two commented out blocks that allow you to use http
+    basic auth to protect your screen sharing while allowing the listed IP
+    addresses to bypass entering credentials.
+
 5. Change the value of the "external-ip" setting in the included
    "turnserver.conf" from "localhost" to your domain. For example if you want
    to host screensy on the domain "example.com", the first two lines of your
@@ -57,7 +61,7 @@ SERVER SETUP (WITH DOCKER)
     external-ip=example.com
 
 6. Make sure the required ports are accessible. We listed these ports at the
-   bottom of this document. 
+   bottom of this document.
 
 7. Start the Docker containers using Docker Compose, by running the following
    command:
@@ -143,6 +147,10 @@ SERVER SETUP (WITHOUT DOCKER)
      }
 
     Keep in mind that most web browsers require HTTPS for WebRTC to work.
+
+    Note there are also two commented out blocks that allow you to use http
+    basic auth to protect your screen sharing while allowing the listed IP
+    addresses to bypass entering credentials.
 
 
 PORTS

--- a/screensy-rendezvous/server.ts
+++ b/screensy-rendezvous/server.ts
@@ -271,7 +271,7 @@ class Room {
         viewer.onclose = (_event: CloseEvent) =>
             this.handleViewerDisconnect(id);
 
-        // Tell the client that he has been assigned the role "broadcaster"
+        // Tell the client that he has been assigned the role "viewer"
         const messageView: MessageView = {
             type: "view",
         };


### PR DESCRIPTION
I wanted a little more security in my screen share than obscurity in the url so I added same basic auth. Then I found it annoying for my usual places of work (home and the office) so I allowed certain IP addresses to bypass the basic auth. I don't know if you are interested in these options (or if I missed a reason why this wasn't necessary or an easier way to do it) but figured I might as well offer my work back. If you like my changes you can have them, if not you can just close the PR or copy my changes and do them differently.