### PR TITLE
Add french translation for Screensy-website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the screensy project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## 1.8.0 - 2022-05-09
+
+### Added
+
+-   Add the Portuguese translation.
+
 ## 1.7.1 - 2022-03-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,4 +39,8 @@ Special thanks to all the people who have helped translate screensy so far:
 
 -   MIDORIINKO
 
+### Portuguese
+
+-   d3adb5
+
 [pull request #32]: https://github.com/screensy/screensy/pull/32

--- a/screensy-website/translations/fr.html
+++ b/screensy-website/translations/fr.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="fr">
+    <head>
+        <meta charset="UTF-8" />
+        <title>screensy</title>
+        <meta name="description" content="Partage d'écran simple pair-à-pair" />
+        <meta name="application-name" content="screensy" />
+        <meta name="language" content="fr" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link href="./styles.css" rel="stylesheet" />
+        <script type="text/javascript" src="./screensy.js"></script>
+    </head>
+    <body>
+        <noscript>
+            <div class="popup">
+                <h1>JavaScript n'est pas pris en charge ou n'est pas activé.</h1>
+                <p>
+                    Screensy nécessite la prise en charge de JavaScript, mais 
+                    votre navigateur ne le permet pas. Utilisez un navigateur qui 
+                    prend en charge JavaScript et assurez-vous qu'il soit activé.
+                </p>
+            </div>
+        </noscript>
+        <div id="access-denied" class="popup hidden">
+            <h1>Vous avez refusé l'accès à votre écran.</h1>
+            <p>
+                Screensy a besoin d'accéder à votre écran afin de le partager,
+                mais vous lui en avez refusé l'accès. Essayez de recharger cette
+                page et autorisez la demande d'accès lorsque votre navigateur vous
+                le demande. Si votre navigateur ne vous demande pas d'autorisation
+                d'accès, vérifiez les paramètres de votre navigateur.
+            </p>
+        </div>
+        <div id="screensharing-not-supported" class="popup hidden">
+            <h1>Le partage d'écran n'est pas pris en charge ou n'est pas activé.</h1>
+            <p>
+                Screensy ne peut pas partager votre écran car votre navigateur
+                ne prend pas en charge le partage d'écran, ou parce qu'il n'est pas
+                activé. Utilisez un navigateur qui prend en charge le partage d'écran
+                et assurez-vous qu'il soit activé.
+            </p>
+        </div>
+        <div id="websockets-not-supported" class="popup hidden">
+            <h1>WebSocket n'est pas pris en charge ou n'est pas activé.</h1>
+            <p>
+                Screensy a besoin de la prise en charge de WebSocket, mais 
+                votre navigateur ne le permet pas. Utilisez un navigateur
+                qui prend en charge WebSocket et assurez-vous que qu'il soit activé.
+            </p>
+        </div>
+        <div id="webrtc-not-supported" class="popup hidden">
+            <h1>WebRTC n'est pas pris en charge ou n'est pas activé.</h1>
+            <p>
+                Screensy a besoin de la prise en charge de WebRTC, mais votre
+                navigateur ne le permet pas. Utilisez un navigateur qui prend en
+                charge WebRTC et assurez-vous qu'il soit activé.
+            </p>
+        </div>
+        <div id="mediastream-not-supported" class="popup hidden">
+            <h1>MediaStream n'est pas pris en charge ou n'est pas activé.</h1>
+            <p>
+                Screensy a besoin de la prise en charge de MediaStream, mais votre
+                navigateur ne le permet pas. Utilisez un navigateur qui prend en
+                charge MediaStream et assurez-vous qu'il soit activé.
+            </p>
+        </div>
+        <div id="websocket-connect-failed" class="popup hidden">
+            <h1>Impossible d'établir une connexion WebSocket.</h1>
+            <p>
+                Screensy doit établir une connexion WebSocket pour se connecter à
+                d'autres utilisateurs, mais il n'y est pas parvenu. Essayez d'utiliser
+                un autre appareil ou contactez l'administrateur de ce site.
+            </p>
+        </div>
+        <div id="broadcaster-disconnected" class="popup hidden">
+            <h1>Le diffuseur s'est déconnecté.</h1>
+        </div>
+        <div id="click-to-share" class="popup clickable hidden">
+            <h1>Cliquez n'importe où pour partager votre écran.</h1>
+        </div>
+        <video
+            id="stream"
+            autoplay="autoplay"
+            muted="muted"
+            controls="controls"
+            playsinline="playsinline"
+        >
+            <div class="popup">
+                <h1>Les balises vidéo ne sont pas prises en charge.</h1>
+                <p>
+                    Screensy a besoin de la prise en charge des balises vidéo, mais
+                    votre navigateur ne le permet pas. Utilisez un navigateur qui
+                    prend en charge les balises vidéo.
+                </p>
+            </div>
+        </video>
+    </body>
+</html>

--- a/screensy-website/translations/pt.html
+++ b/screensy-website/translations/pt.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="pt">
+    <head>
+        <meta charset="UTF-8" />
+        <title>screensy</title>
+        <meta name="description" content="Compartilhamento de tela peer-to-peer simples" />
+        <meta name="application-name" content="screensy" />
+        <meta name="language" content="pt" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link href="./styles.css" rel="stylesheet" />
+        <script type="text/javascript" src="./screensy.js"></script>
+    </head>
+    <body>
+        <noscript>
+            <div class="popup">
+                <h1>JavaScript não é suportado ou não está habilitado.</h1>
+                <p>
+                    O Screensy request suporte a JavaScript, mas seu navegador
+                    não o provê. Use um navegador que tenha suporte a JavaScript
+                    e garanta que este esteja habilitado.
+                </p>
+            </div>
+        </noscript>
+        <div id="access-denied" class="popup hidden">
+            <h1>Você negou o acesso à sua tela.</h1>
+            <p>
+                O Screensy precisa de acesso à sua tela para a conseguir
+                compartilhar, mas você negou tal acesso. Tente recarregar esta
+                página e conceder acesso quando seu navegador pedir. Se seu
+                navegador não pedir acesso à tela, consulte as configurações do
+                navegador.
+            </p>
+        </div>
+        <div id="screensharing-not-supported" class="popup hidden">
+            <h1>O compartilhamento de tela não é suportado ou não está habilitado.</h1>
+            <p>
+                O Screensy não consegue compartilhar a sua tela, pois o
+                navegador não dá suporte a esta operação, ou o suporte não está
+                habilitado. Use um navegador com suporte a compartilhamento de
+                tela e garanta que este esteja habilitado.
+            </p>
+        </div>
+        <div id="websockets-not-supported" class="popup hidden">
+            <h1>WebSocket não é suportado ou não está habilitado.</h1>
+            <p>
+                O Screensy precisa de suporte ao protocolo WebSocket, mas seu
+                navegador não o provê. Use um navegador que tenha suporte a
+                WebSocket e garanta que ele esteja habilitado.
+            </p>
+        </div>
+        <div id="webrtc-not-supported" class="popup hidden">
+            <h1>WebRTC não é suportado ou não está habilitado.</h1>
+            <p>
+                O Screensy precisa de suporte a WebRTC, mas seu navegador não o
+                provê. Use um navegador que tenha suporte a WebRTC e garanta que
+                ele esteja habilitado.
+            </p>
+        </div>
+        <div id="mediastream-not-supported" class="popup hidden">
+            <h1>MediaStream não é suportado ou não está habilitado.</h1>
+            <p>
+                O Screensy precisa de suporte a MediaStream, mas seu navegador
+                não o provê. Use um navegador com suporte a MediaStream e
+                garanta que ele esteja habilitado.
+            </p>
+        </div>
+        <div id="websocket-connect-failed" class="popup hidden">
+            <h1>Não foi possível estabelecer a conexão WebSocket.</h1>
+            <p>
+                O Screensy precisa estabelecer uma conexão WebSocket com outros
+                usuários, mas não o conseguiu fazer. Tente usar outro
+                dispositivo ou contate o administrador deste website.
+            </p>
+        </div>
+        <div id="broadcaster-disconnected" class="popup hidden">
+            <h1>O transmissor desconectou.</h1>
+        </div>
+        <div id="click-to-share" class="popup clickable hidden">
+            <h1>Clique para compartilhar a sua tela.</h1>
+        </div>
+        <video
+            id="stream"
+            autoplay="autoplay"
+            muted="muted"
+            controls="controls"
+            playsinline="playsinline"
+        >
+            <div class="popup">
+                <h1>Tags de vídeo não são suportadas.</h1>
+                <p>
+                    O Screensy precisa de suporte à tag video, mas seu navegador
+                    não o provê. Use um navegador com suporte às tags de vídeo.
+                </p>
+            </div>
+        </video>
+    </body>
+</html>


### PR DESCRIPTION
Please accept this humble contribution from a native speaker.

There is one word specifically that could be up to debate in this translation: **diffuseur**. 
It is not commonly used in this context so I was not sure which one could replace **broadcaster**. I even considered the equivalent of **the host as disconnected** but I finally went with the proper terminology.

If my fellow frenchmen want to challenge this, please do.

_Note: same with **pair-à-pair**. In french, and especially in IT, we often use the english terminology so peer-to-peer would not surpise me but again, I went with the french equivalent._